### PR TITLE
Add support for multiple projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Rolling back: 20151127184807_create_users_table.sql
 The following command line options are available with all commands. You must use command line arguments in the order `dbmate [global options] command [command options]`.
 
 * `--migrations-dir, -d "./db/migrations"` - where to keep the migration files.
+* `--project, -p "project-name"` - a name under which to associate the set of migrations. defaults to 'default'
 * `--env, -e "DATABASE_URL"` - specify an environment variable to read the database connection URL from.
 
 For example, before running your test suite, you may wish to drop and recreate the test database. One easy way to do this is to store your test database connection URL in the `TEST_DATABASE_URL` environment variable:

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -40,6 +40,11 @@ func NewApp() *cli.App {
 			Value: "DATABASE_URL",
 			Usage: "specify an environment variable containing the database URL",
 		},
+		cli.StringFlag{
+			Name: "project, p",
+			Value: "default",
+			Usage: "specify a name to associate with the migration set",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -113,6 +118,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		}
 		db := dbmate.NewDB(u)
 		db.MigrationsDir = c.GlobalString("migrations-dir")
+		db.Project = c.GlobalString("project")
 
 		return f(db, c)
 	}

--- a/db.go
+++ b/db.go
@@ -15,10 +15,14 @@ import (
 // DefaultMigrationsDir specifies default directory to find migration files
 var DefaultMigrationsDir = "./db/migrations"
 
+// DefaultProject specifies the default name to associate with the migrations
+var DefaultProject = "default"
+
 // DB allows dbmate actions to be performed on a specified database
 type DB struct {
 	DatabaseURL   *url.URL
 	MigrationsDir string
+	Project       string
 }
 
 // NewDB initializes a new dbmate database
@@ -26,6 +30,7 @@ func NewDB(databaseURL *url.URL) *DB {
 	return &DB{
 		DatabaseURL:   databaseURL,
 		MigrationsDir: DefaultMigrationsDir,
+		Project:       DefaultProject,
 	}
 }
 
@@ -168,7 +173,7 @@ func (db *DB) Migrate() error {
 	}
 	defer mustClose(sqlDB)
 
-	applied, err := drv.SelectMigrations(sqlDB, -1)
+	applied, err := drv.SelectMigrations(sqlDB, -1, db.Project)
 	if err != nil {
 		return err
 	}
@@ -195,7 +200,7 @@ func (db *DB) Migrate() error {
 			}
 
 			// record migration
-			if err := drv.InsertMigration(tx, ver); err != nil {
+			if err := drv.InsertMigration(tx, ver, db.Project); err != nil {
 				return err
 			}
 
@@ -304,7 +309,7 @@ func (db *DB) Rollback() error {
 	}
 	defer mustClose(sqlDB)
 
-	applied, err := drv.SelectMigrations(sqlDB, 1)
+	applied, err := drv.SelectMigrations(sqlDB, 1, db.Project)
 	if err != nil {
 		return err
 	}

--- a/driver.go
+++ b/driver.go
@@ -13,8 +13,8 @@ type Driver interface {
 	CreateDatabase(*url.URL) error
 	DropDatabase(*url.URL) error
 	CreateMigrationsTable(*sql.DB) error
-	SelectMigrations(*sql.DB, int) (map[string]bool, error)
-	InsertMigration(Transaction, string) error
+	SelectMigrations(*sql.DB, int, string) (map[string]bool, error)
+	InsertMigration(Transaction, string, string) error
 	DeleteMigration(Transaction, string) error
 }
 

--- a/mysql.go
+++ b/mysql.go
@@ -110,18 +110,28 @@ func (drv MySQLDriver) DatabaseExists(u *url.URL) (bool, error) {
 func (drv MySQLDriver) CreateMigrationsTable(db *sql.DB) error {
 	_, err := db.Exec(`create table if not exists schema_migrations (
 		version varchar(255) primary key)`)
+	if err != nil {
+		return err
+	}
+
+	// Add the project column if it doesn't already exist.
+	_, err = db.Exec(`select project from schema_migrations limit 1`)
+	if err != nil {
+		_, err = db.Exec(`alter table schema_migrations
+			add column project varchar(255) default 'default'`)
+	}
 
 	return err
 }
 
 // SelectMigrations returns a list of applied migrations
 // with an optional limit (in descending order)
-func (drv MySQLDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
-	query := "select version from schema_migrations order by version desc"
+func (drv MySQLDriver) SelectMigrations(db *sql.DB, limit int, project string) (map[string]bool, error) {
+	query := "select version from schema_migrations where project = ? order by version desc"
 	if limit >= 0 {
 		query = fmt.Sprintf("%s limit %d", query, limit)
 	}
-	rows, err := db.Query(query)
+	rows, err := db.Query(query, project)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +152,8 @@ func (drv MySQLDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool,
 }
 
 // InsertMigration adds a new migration record
-func (drv MySQLDriver) InsertMigration(db Transaction, version string) error {
-	_, err := db.Exec("insert into schema_migrations (version) values (?)", version)
+func (drv MySQLDriver) InsertMigration(db Transaction, version string, project string) error {
+	_, err := db.Exec("insert into schema_migrations (version, project) values (?, ?)", version, project)
 
 	return err
 }

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -158,18 +158,29 @@ func TestMySQLSelectMigrations(t *testing.T) {
 		values ('abc2'), ('abc1'), ('abc3')`)
 	require.Nil(t, err)
 
-	migrations, err := drv.SelectMigrations(db, -1)
+	migrations, err := drv.SelectMigrations(db, -1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc1"])
 	require.Equal(t, true, migrations["abc2"])
 	require.Equal(t, true, migrations["abc2"])
 
 	// test limit param
-	migrations, err = drv.SelectMigrations(db, 1)
+	migrations, err = drv.SelectMigrations(db, 1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc3"])
 	require.Equal(t, false, migrations["abc1"])
 	require.Equal(t, false, migrations["abc2"])
+
+	// test different project
+	_, err = db.Exec(`insert into schema_migrations (version, project)
+		values ('bcd1', 'app2')`)
+	require.Nil(t, err)
+	migrations, err = drv.SelectMigrations(db, -1, "app2")
+	require.Nil(t, err)
+	require.Equal(t, true, migrations["bcd1"])
+	require.Equal(t, false, migrations["abc1"])
+	require.Equal(t, false, migrations["abc2"])
+	require.Equal(t, false, migrations["abc3"])
 }
 
 func TestMySQLInsertMigration(t *testing.T) {
@@ -186,7 +197,7 @@ func TestMySQLInsertMigration(t *testing.T) {
 	require.Equal(t, 0, count)
 
 	// insert migration
-	err = drv.InsertMigration(db, "abc1")
+	err = drv.InsertMigration(db, "abc1", "default")
 	require.Nil(t, err)
 
 	err = db.QueryRow("select count(*) from schema_migrations where version = 'abc1'").

--- a/postgres.go
+++ b/postgres.go
@@ -83,18 +83,28 @@ func (drv PostgresDriver) DatabaseExists(u *url.URL) (bool, error) {
 func (drv PostgresDriver) CreateMigrationsTable(db *sql.DB) error {
 	_, err := db.Exec(`create table if not exists schema_migrations (
 		version varchar(255) primary key)`)
+	if err != nil {
+		return err
+	}
+
+	// Add the project column if it doesn't already exist.
+	_, err = db.Exec(`select project from schema_migrations limit 1`)
+	if err != nil {
+		_, err = db.Exec(`alter table schema_migrations
+			add column project varchar(255) default 'default'`)
+	}
 
 	return err
 }
 
 // SelectMigrations returns a list of applied migrations
 // with an optional limit (in descending order)
-func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
-	query := "select version from schema_migrations order by version desc"
+func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int, project string) (map[string]bool, error) {
+	query := "select version from schema_migrations where project = $1 order by version desc"
 	if limit >= 0 {
 		query = fmt.Sprintf("%s limit %d", query, limit)
 	}
-	rows, err := db.Query(query)
+	rows, err := db.Query(query, project)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +125,8 @@ func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bo
 }
 
 // InsertMigration adds a new migration record
-func (drv PostgresDriver) InsertMigration(db Transaction, version string) error {
-	_, err := db.Exec("insert into schema_migrations (version) values ($1)", version)
+func (drv PostgresDriver) InsertMigration(db Transaction, version string, project string) error {
+	_, err := db.Exec("insert into schema_migrations (version, project) values ($1, $2)", version, project)
 
 	return err
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -119,18 +119,29 @@ func TestSQLiteSelectMigrations(t *testing.T) {
 		values ('abc2'), ('abc1'), ('abc3')`)
 	require.Nil(t, err)
 
-	migrations, err := drv.SelectMigrations(db, -1)
+	migrations, err := drv.SelectMigrations(db, -1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc1"])
 	require.Equal(t, true, migrations["abc2"])
 	require.Equal(t, true, migrations["abc2"])
 
 	// test limit param
-	migrations, err = drv.SelectMigrations(db, 1)
+	migrations, err = drv.SelectMigrations(db, 1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc3"])
 	require.Equal(t, false, migrations["abc1"])
 	require.Equal(t, false, migrations["abc2"])
+
+	// test different project
+	_, err = db.Exec(`insert into schema_migrations (version, project)
+		values ('bcd1', 'app2')`)
+	require.Nil(t, err)
+	migrations, err = drv.SelectMigrations(db, -1, "app2")
+	require.Nil(t, err)
+	require.Equal(t, true, migrations["bcd1"])
+	require.Equal(t, false, migrations["abc1"])
+	require.Equal(t, false, migrations["abc2"])
+	require.Equal(t, false, migrations["abc3"])
 }
 
 func TestSQLiteInsertMigration(t *testing.T) {
@@ -147,7 +158,7 @@ func TestSQLiteInsertMigration(t *testing.T) {
 	require.Equal(t, 0, count)
 
 	// insert migration
-	err = drv.InsertMigration(db, "abc1")
+	err = drv.InsertMigration(db, "abc1", "default")
 	require.Nil(t, err)
 
 	err = db.QueryRow("select count(*) from schema_migrations where version = 'abc1'").


### PR DESCRIPTION
This change supports storing various sets of migrations under
different, independently-deployable projects. For example, you may use
this tool with the projects app1 and app2. These projects are
responsible for maintaining their own sets of database tables and
should not worry about any other migrations that may have occured.
Thus, the -p (--project) flag can be passed to the dbmate CLI to
restrict its operations to any migrations that may have occurred (or
will need to occur) for the particular project.

For example, usage may look like:
```
/home $ ./dbmate -d app1 -p app1 migrate
Applying: 1495196229_create_users_table.sql
/home $ ./dbmate -d app2 -p app2 migrate
Applying: 1495197370_create_metrics_table.sql
/home $ ./dbmate -d app1 -p app1 down
Rolling back: 1495196229_create_users_table.sql
```