### PR TITLE
Add darwin build target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 1.3.0
+* Add support for projects
+* Add darwin as a build target
+
+## 1.2.1
+* Initial fork from amacneil/dbmate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.8
 
-# required to force cgo (for sqlite driver) with cross compile
-ENV CGO_ENABLED 1
-
 # i386 cross compilation
 RUN dpkg --add-architecture i386 && \
 	apt-get update && \
@@ -11,6 +8,7 @@ RUN dpkg --add-architecture i386 && \
 
 # development dependencies
 RUN go get \
+	github.com/mitchellh/gox \
 	github.com/golang/lint/golint \
 	github.com/kisielk/errcheck
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	$(DC) run dbmate go test -v $(PACKAGES)
 
 build: clean
-	$(DC) run -e GOARCH=386   dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-i386 ./cmd/dbmate
-	$(DC) run -e GOARCH=amd64 dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-amd64 ./cmd/dbmate
-	# musl target does not support sqlite
-	$(DC) run -e GOARCH=amd64 -e CGO_ENABLED=0 dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-musl-amd64 ./cmd/dbmate
+	$(DC) run dbmate gox --output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -cgo -ldflags="-s" -osarch="linux/386" -osarch="linux/amd64" ./cmd/dbmate
+	# neither musl (alpine) nor darwin support cgo for sqlite driver because they
+	# use different C libraries.
+	$(DC) run dbmate gox --output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}-nocgo" -ldflags="-s" -osarch="linux/amd64" -osarch="darwin/amd64" ./cmd/dbmate

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package dbmate
 
 // Version of dbmate
-const Version = "1.2.1"
+const Version = "1.3.0"


### PR DESCRIPTION
mitchellh/gox is used to build 4 binaries:
* dbmate-linux-386
* dbmate-linux-amd64
* dbmate-darwin-amd64-nocgo
* dbmate-linux-amd64-nocgo (for Alpine)