### PR TITLE
Add driver locking/unlocking to ensure distinct runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 1.4.0
+
+* Enable Postgres migrations to acquire an advisory lock to ensure they will
+  execute a single migration run at a time.
+
 ## 1.3.0
+
 * Add support for projects
 * Add darwin as a build target
 
 ## 1.2.1
+
 * Initial fork from amacneil/dbmate

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
 # Dbmate
 
 This project was forked from [amacneil/dbmate](https://github.com/amacneil/dbmate)
-Note that this README still needs to be updated to reflect various changes (especially with regard to homebrew and releases).
+Note that this README still needs to be updated to reflect various changes
+(especially with regard to homebrew and releases).
 
 [![Build Status](https://travis-ci.org/turnitin/dbmate.svg?branch=master)](https://travis-ci.org/turnitin/dbmate)
 [![Go Report Card](https://goreportcard.com/badge/github.com/turnitin/dbmate)](https://goreportcard.com/report/github.com/turnitin/dbmate)
 [![GitHub Release](https://img.shields.io/github/release/turnitin/dbmate.svg)](https://github.com/turnitin/dbmate/releases)
 [![Documentation](https://readthedocs.org/projects/dbmate/badge/)](http://dbmate.readthedocs.org/)
 
-Dbmate is a database migration tool, to keep your database schema in sync across multiple developers and your production servers.
+Dbmate is a database migration tool to keep your database schema in sync
+across multiple developers and your production servers.
 
-It is a standalone command line tool, which can be used with Go, Node.js, Python, Ruby, PHP, or any other language or framework you are using to write database-backed applications. This is especially helpful if you are writing many services in different languages, and want to maintain some sanity with consistent development tools.
+It is a standalone command line tool, which can be used with Go, Node.js,
+Python, Ruby, PHP, or any other language or framework you are using to write
+database-backed applications. This is especially helpful if you are writing
+many services in different languages, and want to maintain some sanity with
+consistent development tools.
 
-For a comparison between dbmate and other popular database schema migration tools, please see the [Alternatives](#alternatives) table.
+For a comparison between dbmate and other popular database schema migration
+tools, please see the [Alternatives](#alternatives) table.
 
 ## Features
 
 * Supports MySQL, PostgreSQL, and SQLite.
-* Powerful, [purpose-built DSL](https://en.wikipedia.org/wiki/SQL#Data_definition) for writing schema migrations.
-* Migrations are timestamp-versioned, to avoid version number conflicts with multiple developers.
+* Powerful, [purpose-built DSL](https://en.wikipedia.org/wiki/SQL#Data_definition)
+  for writing schema migrations.
+* Migrations are timestamp-versioned, to avoid version number conflicts with
+  multiple developers.
 * Migrations are run atomically inside a transaction.
 * Supports creating and dropping databases (handy in development/test).
-* Database connection URL is definied using an environment variable (`DATABASE_URL` by default), or specified on the command line.
+* Database connection URL is definied using an environment variable
+  (`DATABASE_URL` by default), or specified on the command line.
 * Built-in support for reading environment variables from your `.env` file.
 * Easy to distribute, single self-contained binary.
 
@@ -47,7 +57,8 @@ $ sudo chmod +x /usr/local/bin/dbmate
 
 **Heroku**
 
-To use dbmate on Heroku, the easiest method is to store the linux binary in your git repository:
+To use dbmate on Heroku, the easiest method is to store the linux binary in
+your git repository:
 
 ```sh
 $ mkdir -p bin
@@ -87,11 +98,17 @@ dbmate down      # alias for rollback
 
 ## Usage
 
-Dbmate locates your database using the `DATABASE_URL` environment variable by default. If you are writing a [twelve-factor app](http://12factor.net/), you should be storing all connection strings in environment variables.
+Dbmate locates your database using the `DATABASE_URL` environment variable by
+default. If you are writing a [twelve-factor app](http://12factor.net/), you
+should be storing all connection strings in environment variables.
 
-To make this easy in development, dbmate looks for a `.env` file in the current directory, and treats any variables listed there as if they were specified in the current environment (existing environment variables take preference, however).
+To make this easy in development, dbmate looks for a `.env` file in the current
+directory, and treats any variables listed there as if they were specified in
+the current environment (existing environment variables take preference,
+however).
 
-If you do not already have a `.env` file, create one and add your database connection URL:
+If you do not already have a `.env` file, create one and add your database
+connection URL:
 
 ```sh
 $ cat .env
@@ -116,7 +133,9 @@ DATABASE_URL="mysql://username:password@127.0.0.1:3306/database_name"
 
 **PostgreSQL**
 
-When connecting to Postgres, you may need to add the `sslmode=disable` option to your connection string, as dbmate by default requires a TLS connection (some other frameworks/languages allow unencrypted connections by default).
+When connecting to Postgres, you may need to add the `sslmode=disable` option
+to your connection string, as dbmate by default requires a TLS connection (some
+other frameworks/languages allow unencrypted connections by default).
 
 ```sh
 DATABASE_URL="postgres://username:password@127.0.0.1:5432/database_name?sslmode=disable"
@@ -124,13 +143,16 @@ DATABASE_URL="postgres://username:password@127.0.0.1:5432/database_name?sslmode=
 
 **SQLite**
 
-SQLite databases are stored on the filesystem, so you do not need to specify a host. By default, files are relative to the current directory. For example, the following will create a database at `./db/database_name.sqlite3`:
+SQLite databases are stored on the filesystem, so you do not need to specify a
+host. By default, files are relative to the current directory. For example, the
+following will create a database at `./db/database_name.sqlite3`:
 
 ```sh
 DATABASE_URL="sqlite:///db/database_name.sqlite3"
 ```
 
-To specify an absolute path, add an additional forward slash to the path. The following will create a database at `/tmp/database_name.sqlite3`:
+To specify an absolute path, add an additional forward slash to the path. The
+following will create a database at `/tmp/database_name.sqlite3`:
 
 ```sh
 DATABASE_URL="sqlite:////tmp/database_name.sqlite3"
@@ -138,7 +160,9 @@ DATABASE_URL="sqlite:////tmp/database_name.sqlite3"
 
 ### Creating Migrations
 
-To create a new migration, run `dbmate new create_users_table`. You can name the migration anything you like. This will create a file `db/migrations/20151127184807_create_users_table.sql` in the current directory:
+To create a new migration, run `dbmate new create_users_table`. You can name
+the migration anything you like. This will create a file
+`db/migrations/20151127184807_create_users_table.sql` in the current directory:
 
 ```sql
 -- migrate:up
@@ -159,7 +183,10 @@ create table users (
 -- migrate:down
 ```
 
-> Note: Migration files are named in the format `[version]_[description].sql`. Only the version (defined as all leading numeric characters in the file name) is recorded in the database, so you can safely rename a migration file without having any effect on its current application state.
+> Note: Migration files are named in the format `[version]_[description].sql`.
+> Only the version (defined as all leading numeric characters in the file name)
+> is recorded in the database, so you can safely rename a migration file
+> without having any effect on its current application state.
 
 ### Running Migrations
 
@@ -171,11 +198,24 @@ Creating: myapp_development
 Applying: 20151127184807_create_users_table.sql
 ```
 
-> Note: `dbmate up` will create the database if it does not already exist (assuming the current user has permission to create databases). If you want to run migrations without creating the database, run `dbmate migrate`.
+> Note: `dbmate up` will create the database if it does not already exist
+> (assuming the current user has permission to create databases). If you want
+> to run migrations without creating the database, run `dbmate migrate`.
+
+In Postgres, database locking will ensure that:
+
+* only one migration can run at a time, and
+* migrations are only run once
+
+even for migrations kicked off concurrently.
+
+(Locking is a no-op for both MySQL and SQLite.)
 
 ### Rolling Back Migrations
 
-By default, dbmate doesn't know how to roll back a migration. In development, it's often useful to be able to revert your database to a previous state. To accomplish this, implement the `migrate:down` section:
+By default, dbmate doesn't know how to roll back a migration. In development,
+it's often useful to be able to revert your database to a previous state. To
+accomplish this, implement the `migrate:down` section:
 
 ```sql
 -- migrate:up
@@ -198,13 +238,22 @@ Rolling back: 20151127184807_create_users_table.sql
 
 ### Options
 
-The following command line options are available with all commands. You must use command line arguments in the order `dbmate [global options] command [command options]`.
+The following command line options are available with all commands. You must
+use command line arguments in the order:
 
-* `--migrations-dir, -d "./db/migrations"` - where to keep the migration files.
-* `--project, -p "project-name"` - a name under which to associate the set of migrations. defaults to 'default'
-* `--env, -e "DATABASE_URL"` - specify an environment variable to read the database connection URL from.
+```
+$ dbmate [global options] command [command options]
+```
 
-For example, before running your test suite, you may wish to drop and recreate the test database. One easy way to do this is to store your test database connection URL in the `TEST_DATABASE_URL` environment variable:
+* `--migrations-dir, -d` - where to keep the migration files, defaults to `./db/migrations`
+* `--project, -p "project-name"` - a name under which to associate the set of
+  migrations. defaults to `default`
+* `--env, -e "DATABASE_URL"` - specify an environment variable to read the
+  database connection URL from, defaults to `DATABASE_URL`
+
+For example, before running your test suite, you may wish to drop and recreate
+the test database. One easy way to do this is to store your test database
+connection URL in the `TEST_DATABASE_URL` environment variable:
 
 ```sh
 $ cat .env
@@ -225,11 +274,19 @@ Applying: 20151127184807_create_users_table.sql
 
 **How do I use dbmate under Alpine linux?**
 
-Alpine linux uses [musl libc](https://www.musl-libc.org/), which is incompatible with how we build SQLite support (using [cgo](https://golang.org/cmd/cgo/)). If you want Alpine linux support, and don't mind sacrificing SQLite support, please use the `dbmate-linux-musl-amd64` build found on the [releases page](https://github.com/amacneil/dbmate/releases).
+Alpine linux uses [musl libc](https://www.musl-libc.org/), which is
+incompatible with how we build SQLite support (using
+[cgo](https://golang.org/cmd/cgo/)). If you want Alpine linux support, and
+don't mind sacrificing SQLite support, please use the `dbmate-linux-musl-amd64`
+build found on the [releases page](https://github.com/amacneil/dbmate/releases).
 
 ## Alternatives
 
-Why another database schema migration tool? Dbmate was inspired by many other tools, primarily [Rails' ActiveRecord](http://guides.rubyonrails.org/active_record_migrations.html), with the goals of being trivial to configure, and language & framework independent. Here is a comparison between dbmate and other popular migration tools.
+Why another database schema migration tool? Dbmate was inspired by many other
+tools, primarily [Rails' ActiveRecord](http://guides.rubyonrails.org/active_record_migrations.html),
+with the goals of being trivial to configure, and language & framework
+independent. Here is a comparison between dbmate and other popular migration
+tools.
 
 | | [goose](https://bitbucket.org/liamstask/goose/) | [sql-migrate](https://github.com/rubenv/sql-migrate) | [mattes/migrate](https://github.com/mattes/migrate) | [activerecord](http://guides.rubyonrails.org/active_record_migrations.html) | [sequelize](http://docs.sequelizejs.com/manual/tutorial/migrations.html) | [dbmate](https://github.com/amacneil/dbmate) |
 | --- |:---:|:---:|:---:|:---:|:---:|:---:|
@@ -248,13 +305,15 @@ Why another database schema migration tool? Dbmate was inspired by many other to
 
 > :eight_pointed_black_star: In theory these tools could be used with other languages, but a Go development environment is required because binary builds are not provided.
 
-*If you notice any inaccuracies in this table, please [propose a change](https://github.com/turnitin/dbmate/edit/master/README.md).*
+*If you notice any inaccuracies in this table, please
+[propose a change](https://github.com/turnitin/dbmate/edit/master/README.md).*
 
 ## Contributing
 
 Dbmate is written in Go, pull requests are welcome.
 
-Tests are run against a real database using docker-compose. First, install the [Docker Toolbox](https://www.docker.com/docker-toolbox).
+Tests are run against a real database using docker-compose. First, install the
+[Docker Toolbox](https://www.docker.com/docker-toolbox).
 
 Make sure you have docker running:
 

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -45,6 +45,11 @@ func NewApp() *cli.App {
 			Value: "default",
 			Usage: "specify a name to associate with the migration set",
 		},
+		cli.IntFlag{
+			Name:  "timeout, t",
+			Value: 30,
+			Usage: "specify the max time we'll wait to acquire a migration lock",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -61,7 +66,7 @@ func NewApp() *cli.App {
 			Name:  "up",
 			Usage: "Create database (if necessary) and migrate to the latest version",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				return db.Up()
+				return db.Up(c.GlobalInt("timeout"))
 			}),
 		},
 		{
@@ -82,7 +87,7 @@ func NewApp() *cli.App {
 			Name:  "migrate",
 			Usage: "Migrate to the latest version",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				return db.Migrate()
+				return db.Migrate(c.GlobalInt("timeout"))
 			}),
 		},
 		{

--- a/db_test.go
+++ b/db_test.go
@@ -44,7 +44,7 @@ func testMigrateURL(t *testing.T, u *url.URL) {
 	require.Nil(t, err)
 
 	// migrate
-	err = db.Migrate()
+	err = db.Migrate(15)
 	require.Nil(t, err)
 
 	// verify results
@@ -77,7 +77,7 @@ func testUpURL(t *testing.T, u *url.URL) {
 	require.Nil(t, err)
 
 	// create and migrate
-	err = db.Up()
+	err = db.Up(30)
 	require.Nil(t, err)
 
 	// verify results
@@ -110,7 +110,7 @@ func testRollbackURL(t *testing.T, u *url.URL) {
 	require.Nil(t, err)
 	err = db.Create()
 	require.Nil(t, err)
-	err = db.Migrate()
+	err = db.Migrate(30)
 	require.Nil(t, err)
 
 	// verify migration

--- a/driver.go
+++ b/driver.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // Driver provides top level database functions
@@ -16,11 +17,35 @@ type Driver interface {
 	SelectMigrations(*sql.DB, int, string) (map[string]bool, error)
 	InsertMigration(Transaction, string, string) error
 	DeleteMigration(Transaction, string) error
+	Lock(*sql.DB) error
+	Unlock(*sql.DB)
 }
 
 // Transaction can represent a database or open transaction
 type Transaction interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
+// RunInLock will execute a function in the context of the driver's advisory lock
+func RunInLock(driver Driver, sqlDB *sql.DB, timeoutSecs int, lockFunc func(Driver, *sql.DB) error) error {
+	lockChan := make(chan string, 1)
+	errChan := make(chan error, 1)
+	go func() {
+		if err := driver.Lock(sqlDB); err != nil {
+			errChan <- err
+		} else {
+			lockChan <- "acquired"
+		}
+	}()
+	select {
+	case <-lockChan:
+		defer driver.Unlock(sqlDB)
+		return lockFunc(driver, sqlDB)
+	case err := <-errChan:
+		return err
+	case <-time.After(time.Second * time.Duration(timeoutSecs)):
+		return fmt.Errorf("Timeout waiting for database migration lock (waited %v seconds)", timeoutSecs)
+	}
 }
 
 // GetDriver loads a database driver by name

--- a/mysql.go
+++ b/mysql.go
@@ -164,3 +164,13 @@ func (drv MySQLDriver) DeleteMigration(db Transaction, version string) error {
 
 	return err
 }
+
+// Lock locks the database so no other migrations can be run, no-op in MySQL
+func (drv MySQLDriver) Lock(db *sql.DB) error {
+	return nil
+}
+
+// Unlock removes a database lock so other migrations can be run, no-op in MySQL
+func (drv MySQLDriver) Unlock(db *sql.DB) {
+	// no-op
+}

--- a/postgres.go
+++ b/postgres.go
@@ -137,3 +137,19 @@ func (drv PostgresDriver) DeleteMigration(db Transaction, version string) error 
 
 	return err
 }
+
+var lockKey = 48372615
+
+// Lock tries to acquire an advisory lock
+func (drv PostgresDriver) Lock(db *sql.DB) error {
+	_, err := db.Exec("select pg_advisory_lock($1)", lockKey)
+	return err
+}
+
+// Unlock releases an advisory lock
+func (drv PostgresDriver) Unlock(db *sql.DB) {
+	_, err := db.Exec("select pg_advisory_unlock($1)", lockKey)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -208,3 +208,24 @@ func TestPostgresDeleteMigration(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, count)
 }
+
+func TestPostgresLock(t *testing.T) {
+	drv := PostgresDriver{}
+	db := prepTestPostgresDB(t)
+	defer mustClose(db)
+
+	err := drv.Lock(db)
+	require.Nil(t, err)
+	defer drv.Unlock(db)
+
+	objectID := 0
+	lockType := "lol"
+	isGranted := false
+
+	row := db.QueryRow("select objid, mode, granted from pg_locks where objid = 48372615")
+	err = row.Scan(&objectID, &lockType, &isGranted)
+	require.Nil(t, err)
+	require.Equal(t, objectID, 48372615)
+	require.Equal(t, lockType, "ExclusiveLock")
+	require.Equal(t, isGranted, true)
+}

--- a/sqlite.go
+++ b/sqlite.go
@@ -127,3 +127,13 @@ func (drv SQLiteDriver) DeleteMigration(db Transaction, version string) error {
 
 	return err
 }
+
+// Lock locks the database so no other migrations can be run, no-op in SQLite
+func (drv SQLiteDriver) Lock(db *sql.DB) error {
+	return nil
+}
+
+// Unlock removes a database lock so other migrations can be run, no-op in SQLite
+func (drv SQLiteDriver) Unlock(db *sql.DB) {
+	// no-op
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package dbmate
 
 // Version of dbmate
-const Version = "1.3.0"
+const Version = "1.4.0"


### PR DESCRIPTION
* We acquire a lock before fetching applied migrations and release it
  after applying them; this ensures that only one migration can be
  applied at a time, no matter what project they're being run from.
* This is currently only implemented in Postgres and is a no-op in
  SQLite and MySQL (which means they behave exactly as they did before).
* Cosmetic: Reformat the README to make it easier to edit