### PR TITLE
Add an explicit lock_timeout at connection time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.0
+
+* Add explicit lock timeout (currently 30 seconds) - https://github.com/turnitin/dbmate/pull/9
+* Update mysql driver to 1.5.1 - https://github.com/turnitin/dbmate/pull/10
+
 ## 1.5.0
 
 * Add 'force' command to record the unapplied migrations from the filesystem in

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package dbmate
 
 // Version of dbmate
-const Version = "1.5.1"
+const Version = "1.6.0"


### PR DESCRIPTION
* This prevents a process from waiting forever for an advisory lock; in
  theory this shouldn't happen because any error encountered during
  migrations should remove the lock. But you never know...
* The `set lock_timeout = val` construct gets run when we open the
  connection and should persist for the entire client session.

For some reason mysql tests are failing on my local machine with `make test` 🤷‍♀ 